### PR TITLE
Add config validation and run summaries

### DIFF
--- a/docs/03-project-layout-and-guidelines.md
+++ b/docs/03-project-layout-and-guidelines.md
@@ -17,6 +17,7 @@ This repo is intentionally small and tutorial-shaped. The code and docs should s
 - Keep all tutorial commands runnable from repo root.
 - Prefer streamed datasets over full downloads.
 - Start with sanity configs before full configs.
+- Fail fast on invalid config values before starting long runs.
 - Keep tokenizer, checkpoints, and exports under `artifacts/`.
 - Avoid hidden magic in docs. Every command should point to a real file in this repo.
 - Do not create a `.ai/` folder.

--- a/docs/04-tokenizer-training.md
+++ b/docs/04-tokenizer-training.md
@@ -22,6 +22,7 @@ python scripts/train_tokenizer.py \
 - Trains a ByteLevel BPE tokenizer
 - Saves Hugging Face compatible tokenizer artifacts
 - Stores a small metadata file with the training settings
+- Validates the model config first and prints a short run summary before work begins
 
 ## Defaults worth keeping
 

--- a/docs/05-pretraining-on-tinystories.md
+++ b/docs/05-pretraining-on-tinystories.md
@@ -15,6 +15,7 @@ python scripts/train_pretrain.py \
 The sanity config uses a reduced token budget so you can confirm:
 
 - device selection works
+- config validation passes before the job starts
 - loss decreases
 - checkpoints save correctly
 - evaluation can read the saved output
@@ -44,3 +45,4 @@ The default model target is approximately 26M parameters with:
 - Float16 autocast is the practical default on Mac.
 - Gradient checkpointing is optional and enabled in the fuller config.
 - Keep sequence length at 256 while validating the end-to-end path.
+- The training script prints a run summary before it begins token processing so you can catch wrong paths or budgets early.

--- a/docs/08-hacker-news-domain-adaptation.md
+++ b/docs/08-hacker-news-domain-adaptation.md
@@ -30,6 +30,8 @@ python scripts/prepare_hackernews.py \
   --preview 10
 ```
 
+The preview command validates the train config first and prints the resolved dataset settings so you can confirm the year range and filter mode before adaptation.
+
 ## Run a small adaptation job
 
 ```bash

--- a/scripts/adapt_hackernews.py
+++ b/scripts/adapt_hackernews.py
@@ -3,6 +3,8 @@ import argparse
 import subprocess
 import sys
 
+from cap.config import ConfigError, load_json_config, validate_train_config
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Continue training from a base checkpoint on Hacker News.")
@@ -14,6 +16,12 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
+    try:
+        train_config = validate_train_config(load_json_config(args.train_config))
+    except ConfigError as exc:
+        raise SystemExit(str(exc)) from exc
+    if train_config["dataset"]["name"] != "open-index/hacker-news":
+        raise SystemExit("Hacker News adaptation requires configs/train/hackernews_adapt.json or another open-index/hacker-news config.")
     command = [
         sys.executable,
         "scripts/train_pretrain.py",

--- a/scripts/prepare_hackernews.py
+++ b/scripts/prepare_hackernews.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 import argparse
-import json
-from pathlib import Path
 
+from cap.config import ConfigError, load_json_config, print_run_summary, validate_train_config
 from cap.data import iter_hackernews_text
 
 
@@ -15,8 +14,23 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    cfg = json.loads(Path(args.config).read_text())
+    try:
+        cfg = validate_train_config(load_json_config(args.config))
+    except ConfigError as exc:
+        raise SystemExit(str(exc)) from exc
     dataset_cfg = cfg["dataset"]
+    print_run_summary(
+        "Hacker News preview",
+        [
+            ("dataset", dataset_cfg["name"]),
+            ("split", dataset_cfg["split"]),
+            ("year_start", dataset_cfg.get("year_start")),
+            ("year_end", dataset_cfg.get("year_end")),
+            ("include_comments", dataset_cfg.get("include_comments", True)),
+            ("include_stories", dataset_cfg.get("include_stories", True)),
+            ("preview", args.preview),
+        ],
+    )
 
     for index, text in enumerate(
         iter_hackernews_text(

--- a/scripts/train_pretrain.py
+++ b/scripts/train_pretrain.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import argparse
-import json
 import math
 import time
 from contextlib import nullcontext
@@ -10,6 +9,7 @@ import torch
 from torch.utils.data import DataLoader
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from cap.config import ConfigError, load_json_config, print_run_summary, validate_model_config, validate_train_config
 from cap.data import PackedHackerNewsDataset, PackedTinyStoriesDataset
 from cap.modeling import build_llama_model
 
@@ -93,14 +93,32 @@ def evaluate(model, loader, device: str, amp_context, max_batches: int):
 
 def main() -> None:
     args = parse_args()
-    model_config = json.loads(Path(args.model_config).read_text())
-    train_config = json.loads(Path(args.train_config).read_text())
+    try:
+        model_config = validate_model_config(load_json_config(args.model_config))
+        train_config = validate_train_config(load_json_config(args.train_config))
+    except ConfigError as exc:
+        raise SystemExit(str(exc)) from exc
     output_dir = Path(train_config["output_dir"])
     output_dir.mkdir(parents=True, exist_ok=True)
 
     tokenizer = AutoTokenizer.from_pretrained(train_config["tokenizer_dir"])
     device = pick_device()
-    print(f"device: {device}")
+    print_run_summary(
+        "Training run",
+        [
+            ("model_name", model_config["name"]),
+            ("dataset", train_config["dataset"]["name"]),
+            ("split", train_config["dataset"]["split"]),
+            ("output_dir", output_dir),
+            ("tokenizer_dir", train_config["tokenizer_dir"]),
+            ("device", device),
+            ("sequence_length", train_config["sequence_length"]),
+            ("micro_batch_size", train_config["micro_batch_size"]),
+            ("gradient_accumulation_steps", train_config["gradient_accumulation_steps"]),
+            ("total_tokens", train_config["total_tokens"]),
+            ("init_checkpoint", args.init_checkpoint or "<none>"),
+        ],
+    )
 
     if device in {"mps", "cuda"}:
         amp_context = torch.autocast(device_type=device, dtype=torch.float16)
@@ -139,8 +157,16 @@ def main() -> None:
         * train_config["gradient_accumulation_steps"]
     )
     total_steps = math.ceil(train_config["total_tokens"] / tokens_per_step)
-    print(f"tokens_per_step: {tokens_per_step}")
-    print(f"total_steps: {total_steps}")
+    print_run_summary(
+        "Training schedule",
+        [
+            ("tokens_per_step", tokens_per_step),
+            ("total_steps", total_steps),
+            ("learning_rate", train_config["learning_rate"]),
+            ("min_learning_rate", train_config["min_learning_rate"]),
+            ("save_every_steps", train_config["save_every_steps"]),
+        ],
+    )
 
     train_loader = build_loader(tokenizer, train_config, split=train_config["dataset"]["split"])
     eval_loader = build_loader(tokenizer, train_config, split=train_config["dataset"]["split"])

--- a/scripts/train_tokenizer.py
+++ b/scripts/train_tokenizer.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 import argparse
-import json
 from pathlib import Path
 
 from datasets import load_dataset
 from tokenizers import Tokenizer, decoders, models, pre_tokenizers, trainers
 from transformers import PreTrainedTokenizerFast
+
+from cap.config import ConfigError, load_json_config, print_run_summary, validate_model_config
 
 
 def parse_args() -> argparse.Namespace:
@@ -20,15 +21,25 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    config = json.loads(Path(args.config).read_text())
+    try:
+        config = validate_model_config(load_json_config(args.config))
+    except ConfigError as exc:
+        raise SystemExit(str(exc)) from exc
+
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    special_tokens = [
-        config["unk_token"],
-        config["bos_token"],
-        config["eos_token"],
-    ]
+    special_tokens = [config["unk_token"], config["bos_token"], config["eos_token"]]
+    print_run_summary(
+        "Tokenizer run",
+        [
+            ("model_name", config["name"]),
+            ("dataset", "roneneldan/TinyStories"),
+            ("output_dir", output_dir),
+            ("max_stories", args.max_stories),
+            ("vocab_size", config["vocab_size"]),
+        ],
+    )
 
     dataset = load_dataset("roneneldan/TinyStories", split="train", streaming=True)
     dataset = dataset.shuffle(buffer_size=args.shuffle_buffer, seed=args.seed)

--- a/src/cap/config.py
+++ b/src/cap/config.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+class ConfigError(ValueError):
+    """Raised when a tutorial config file is missing required values or is malformed."""
+
+
+def load_json_config(path: str) -> dict:
+    config_path = Path(path)
+    if not config_path.exists():
+        raise ConfigError(f"Config file not found: {config_path}")
+    try:
+        return json.loads(config_path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"Invalid JSON in {config_path}: {exc}") from exc
+
+
+def _require_keys(config: dict, required_keys: list[str], label: str) -> None:
+    missing = [key for key in required_keys if key not in config]
+    if missing:
+        joined = ", ".join(missing)
+        raise ConfigError(f"{label} is missing required keys: {joined}")
+
+
+def validate_model_config(config: dict) -> dict:
+    _require_keys(
+        config,
+        [
+            "name",
+            "vocab_size",
+            "hidden_size",
+            "intermediate_size",
+            "num_hidden_layers",
+            "num_attention_heads",
+            "num_key_value_heads",
+            "rms_norm_eps",
+            "hidden_act",
+            "max_position_embeddings",
+            "rope_theta",
+            "bos_token",
+            "eos_token",
+            "unk_token",
+            "pad_token",
+        ],
+        "Model config",
+    )
+    for key in ["vocab_size", "hidden_size", "intermediate_size", "num_hidden_layers", "num_attention_heads", "num_key_value_heads", "max_position_embeddings"]:
+        if int(config[key]) <= 0:
+            raise ConfigError(f"Model config value must be > 0: {key}={config[key]}")
+    return config
+
+
+def validate_train_config(config: dict) -> dict:
+    _require_keys(
+        config,
+        [
+            "output_dir",
+            "tokenizer_dir",
+            "dataset",
+            "sequence_length",
+            "micro_batch_size",
+            "gradient_accumulation_steps",
+            "total_tokens",
+            "warmup_steps",
+            "learning_rate",
+            "min_learning_rate",
+            "weight_decay",
+            "adam_beta1",
+            "adam_beta2",
+            "adam_epsilon",
+            "grad_clip",
+            "eval_every_steps",
+            "eval_batches",
+            "save_every_steps",
+            "max_train_examples",
+            "seed",
+            "use_gradient_checkpointing",
+        ],
+        "Train config",
+    )
+    dataset = config["dataset"]
+    _require_keys(dataset, ["name", "split", "streaming"], "Train config dataset")
+    for key in ["sequence_length", "micro_batch_size", "gradient_accumulation_steps", "total_tokens", "eval_every_steps", "eval_batches", "save_every_steps"]:
+        if int(config[key]) <= 0:
+            raise ConfigError(f"Train config value must be > 0: {key}={config[key]}")
+    if float(config["learning_rate"]) <= 0:
+        raise ConfigError("Train config learning_rate must be > 0")
+    if float(config["min_learning_rate"]) < 0:
+        raise ConfigError("Train config min_learning_rate must be >= 0")
+    if dataset["name"] not in {"roneneldan/TinyStories", "open-index/hacker-news"}:
+        raise ConfigError(f"Unsupported dataset name: {dataset['name']}")
+    return config
+
+
+def print_run_summary(title: str, rows: list[tuple[str, object]]) -> None:
+    print(f"{title}:")
+    for key, value in rows:
+        print(f"  {key}: {value}")


### PR DESCRIPTION
## Summary
- add shared config loading and validation helpers
- print concise run summaries before tokenizer, training, and Hacker News prep runs
- document the new fail-fast validation behavior in the tutorial docs

## Testing
- python3 -m compileall src scripts

Closes #4
