### PR TITLE
Fix tokenizer smoke-test regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .venv/
 __pycache__/
 *.pyc
+*.egg-info/
 
 artifacts/.hf/
 artifacts/checkpoints/

--- a/scripts/train_tokenizer.py
+++ b/scripts/train_tokenizer.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import json
 from pathlib import Path
 
 from datasets import load_dataset


### PR DESCRIPTION
## Summary
- add the missing json import back to the tokenizer script
- ignore generated egg-info artifacts from local editable installs

## Testing
- python3 -m compileall scripts/train_tokenizer.py
- ./.venv/bin/python scripts/train_tokenizer.py --config configs/model/cap_26m.json --output-dir artifacts/tokenizers/cap-bytebpe-smoke --max-stories 200 --shuffle-buffer 500

Closes #6
