### PR TITLE
Improve training startup logs

### DIFF
--- a/docs/02-environment-setup.md
+++ b/docs/02-environment-setup.md
@@ -46,6 +46,12 @@ export HF_DATASETS_CACHE="$HF_HOME/datasets"
 mkdir -p "$HF_HUB_CACHE" "$HF_DATASETS_CACHE"
 ```
 
+If you have a Hugging Face access token, export it in your shell before long runs so dataset access is less rate-limited:
+
+```bash
+export HF_TOKEN="your_token_here"
+```
+
 ## MPS safety knobs
 
 Use CPU fallback for unsupported MPS ops:

--- a/docs/05-pretraining-on-tinystories.md
+++ b/docs/05-pretraining-on-tinystories.md
@@ -6,6 +6,7 @@ This is the main tutorial path. Get this working before touching Hacker News.
 
 ```bash
 source .venv/bin/activate
+export HF_TOKEN="your_token_here"
 export PYTORCH_ENABLE_MPS_FALLBACK=1
 python scripts/train_pretrain.py \
   --model-config configs/model/cap_26m.json \
@@ -16,6 +17,7 @@ The sanity config uses a reduced token budget so you can confirm:
 
 - device selection works
 - config validation passes before the job starts
+- startup stage logs show tokenizer loading, model build, dataloader setup, and the first batch
 - loss decreases
 - checkpoints save correctly
 - evaluation can read the saved output

--- a/scripts/train_pretrain.py
+++ b/scripts/train_pretrain.py
@@ -14,6 +14,11 @@ from cap.data import PackedHackerNewsDataset, PackedTinyStoriesDataset
 from cap.modeling import build_llama_model
 
 
+def log_stage(message: str) -> None:
+    timestamp = time.strftime("%H:%M:%S")
+    print(f"[{timestamp}] {message}", flush=True)
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Train the Cap tutorial model.")
     parser.add_argument("--model-config", required=True, help="Path to model config JSON.")
@@ -94,6 +99,7 @@ def evaluate(model, loader, device: str, amp_context, max_batches: int):
 def main() -> None:
     args = parse_args()
     try:
+        log_stage("Loading model and training configs")
         model_config = validate_model_config(load_json_config(args.model_config))
         train_config = validate_train_config(load_json_config(args.train_config))
     except ConfigError as exc:
@@ -101,6 +107,7 @@ def main() -> None:
     output_dir = Path(train_config["output_dir"])
     output_dir.mkdir(parents=True, exist_ok=True)
 
+    log_stage("Loading tokenizer")
     tokenizer = AutoTokenizer.from_pretrained(train_config["tokenizer_dir"])
     device = pick_device()
     print_run_summary(
@@ -125,6 +132,7 @@ def main() -> None:
     else:
         amp_context = nullcontext()
 
+    log_stage("Building model")
     if args.init_checkpoint:
         model = AutoModelForCausalLM.from_pretrained(args.init_checkpoint).to(device)
     else:
@@ -132,6 +140,7 @@ def main() -> None:
     if train_config.get("use_gradient_checkpointing"):
         model.gradient_checkpointing_enable()
 
+    log_stage("Preparing optimizer")
     decay, no_decay = [], []
     for name, parameter in model.named_parameters():
         if not parameter.requires_grad:
@@ -168,17 +177,24 @@ def main() -> None:
         ],
     )
 
+    log_stage("Building training dataloader")
     train_loader = build_loader(tokenizer, train_config, split=train_config["dataset"]["split"])
+    log_stage("Building evaluation dataloader")
     eval_loader = build_loader(tokenizer, train_config, split=train_config["dataset"]["split"])
 
     optimizer.zero_grad(set_to_none=True)
     running_tokens = 0
     started_at = time.time()
+    first_step_started_at = None
 
     model.train()
+    log_stage("Starting training loop")
     for step, (x, y) in enumerate(train_loader, start=1):
         if step > total_steps:
             break
+        if step == 1:
+            first_step_started_at = time.time()
+            log_stage("Received first batch from dataset stream")
 
         lr = lr_schedule(step, total_steps, train_config)
         for param_group in optimizer.param_groups:
@@ -200,18 +216,22 @@ def main() -> None:
 
         running_tokens += x.numel()
 
-        if step % 50 == 0:
+        if step == 1 and first_step_started_at is not None:
+            log_stage(f"Completed first backward pass in {time.time() - first_step_started_at:.1f}s")
+
+        if step <= 10 or step % 50 == 0:
             elapsed = time.time() - started_at
             tok_per_sec = running_tokens / max(elapsed, 1e-9)
             print(
                 f"step={step}/{total_steps} lr={lr:.2e} "
                 f"loss={loss.item() * train_config['gradient_accumulation_steps']:.4f} "
-                f"tok_per_sec={tok_per_sec:.0f}"
+                f"tok_per_sec={tok_per_sec:.0f}",
+                flush=True,
             )
 
         if step % train_config["eval_every_steps"] == 0:
             eval_loss, eval_ppl = evaluate(model, eval_loader, device, amp_context, train_config["eval_batches"])
-            print(f"eval_step={step} eval_loss={eval_loss:.4f} eval_ppl={eval_ppl:.2f}")
+            print(f"eval_step={step} eval_loss={eval_loss:.4f} eval_ppl={eval_ppl:.2f}", flush=True)
 
         if step % train_config["save_every_steps"] == 0:
             checkpoint_dir = output_dir / f"checkpoint-step-{step}"
@@ -222,11 +242,11 @@ def main() -> None:
                 {"step": step, "optimizer": optimizer.state_dict()},
                 checkpoint_dir / "trainer_state.pt",
             )
-            print(f"saved_checkpoint: {checkpoint_dir}")
+            print(f"saved_checkpoint: {checkpoint_dir}", flush=True)
 
     model.save_pretrained(output_dir, safe_serialization=True)
     tokenizer.save_pretrained(output_dir)
-    print(f"saved_final_model: {output_dir}")
+    print(f"saved_final_model: {output_dir}", flush=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- improve training startup logs so long runs are easier to monitor
- document optional HF_TOKEN export for faster Hugging Face access
- document the new startup-stage logging in the TinyStories training guide

## Testing
- python3 -m compileall scripts/train_pretrain.py
- tokenizer build completed at artifacts/tokenizers/cap-bytebpe
- TinyStories sanity training completed and saved artifacts/checkpoints/cap-26m-sanity
- sample generation succeeded from artifacts/checkpoints/cap-26m-sanity

Closes #8
