### PR TITLE
Add quality continuation config

### DIFF
--- a/configs/train/tinystories_quality_continue.json
+++ b/configs/train/tinystories_quality_continue.json
@@ -1,0 +1,28 @@
+{
+  "output_dir": "artifacts/checkpoints/cap-26m-quality-continue",
+  "tokenizer_dir": "artifacts/tokenizers/cap-bytebpe",
+  "dataset": {
+    "name": "roneneldan/TinyStories",
+    "subset": null,
+    "split": "train",
+    "streaming": true
+  },
+  "sequence_length": 256,
+  "micro_batch_size": 8,
+  "gradient_accumulation_steps": 16,
+  "total_tokens": 200000000,
+  "warmup_steps": 100,
+  "learning_rate": 0.00005,
+  "min_learning_rate": 0.00001,
+  "weight_decay": 0.1,
+  "adam_beta1": 0.9,
+  "adam_beta2": 0.95,
+  "adam_epsilon": 1e-08,
+  "grad_clip": 1.0,
+  "eval_every_steps": 250,
+  "eval_batches": 20,
+  "save_every_steps": 250,
+  "max_train_examples": 0,
+  "seed": 42,
+  "use_gradient_checkpointing": true
+}

--- a/docs/05-pretraining-on-tinystories.md
+++ b/docs/05-pretraining-on-tinystories.md
@@ -50,6 +50,17 @@ python scripts/train_pretrain.py \
   --train-config configs/train/tinystories_quality.json
 ```
 
+## Quality continuation run
+
+Use this when `cap-26m-fast-dev` is your strongest checkpoint and you want a safer long run than restarting from scratch:
+
+```bash
+python scripts/train_pretrain.py \
+  --model-config configs/model/cap_26m.json \
+  --train-config configs/train/tinystories_quality_continue.json \
+  --init-checkpoint artifacts/checkpoints/cap-26m-fast-dev
+```
+
 ## Model shape
 
 The default model target is approximately 26M parameters with:
@@ -69,3 +80,4 @@ The default model target is approximately 26M parameters with:
 - Keep sequence length at 256 while validating the end-to-end path.
 - The training script prints a run summary before it begins token processing so you can catch wrong paths or budgets early.
 - The `fast-dev` config is for quick debugging; the `quality` config is for a longer run you should launch in your own terminal.
+- If the scratch `quality` run degrades model quality, prefer `tinystories_quality_continue.json` with `--init-checkpoint artifacts/checkpoints/cap-26m-fast-dev`.

--- a/docs/06-evaluation-and-sampling.md
+++ b/docs/06-evaluation-and-sampling.md
@@ -63,5 +63,6 @@ If you want better quality:
 
 - train longer than the sanity token budget
 - use `configs/train/tinystories_quality.json` or another longer TinyStories config after sanity succeeds
+- if the scratch quality run degrades, continue from `cap-26m-fast-dev` with `configs/train/tinystories_quality_continue.json`
 - compare eval loss and perplexity across checkpoints instead of relying only on one prompt
 - add a second-stage adaptation pass only after the base TinyStories model is stable


### PR DESCRIPTION
## Summary
- add a safer TinyStories continuation config for runs that should build on cap-26m-fast-dev
- document when to use the continuation config instead of restarting from scratch
- keep the continuation workflow explicit about --init-checkpoint

## Testing
- python3 -m json.tool configs/train/tinystories_quality_continue.json

Closes #14
